### PR TITLE
Removing some names

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 Talia Ringer, Nate Yazdani
+Copyright (c) 2019 ...
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In general, DEVOID can lift functions and proofs across **any equivalence that c
 For change that don't fall into the above four buckets, you need to supply the configuration for that equivalence yourself.
 This is not yet documented here due to time constraints (I promise I will document it soon).
 For now, check out two examples: switching between unary and binary natural numbers [here](/plugin/coq/nonorn.v),
-and an easier refactoring of constructors [here](https://github.com/uwplse/ornamental-search/blob/master/plugin/coq/playground/constr_refactor.v).
+and an easier refactoring of constructors [here](redacted).
 
 # Getting Started with DEVOID
 
@@ -31,9 +31,9 @@ Please report any issues you encounter to GitHub issues, and please feel free to
 
 The only dependency you need to install yourself in order to use DEVOID is Coq 8.8. 
 DEVOID also depends on a
-[Coq plugin library](https://github.com/uwplse/coq-plugin-lib) which is included
+[Coq plugin library](redacted) which is included
 as a submodule automatically in the build script,
-and on the [fix-to-elim](https://github.com/uwplse/fix-to-elim) plugin, which is also included. To build DEVOID, run these commands:
+and on the [fix-to-elim](redacted) plugin, which is also included. To build DEVOID, run these commands:
 
 ```
 cd plugin
@@ -56,7 +56,7 @@ then DEVOID will run `Find ornament` for you automatically first.
 In addition, there are a few commands that help make DEVOID more useful: `Preprocess`
 for pattern matching and fixpoint support, and `Unpack` to help recover more user-friendly types.
 The `Preprocess` command comes from our plugin
-[fix-to-elim](https://github.com/uwplse/coq-plugin-lib).
+[fix-to-elim](redacted).
 There is also work in progress on a general methodology (which will hopefully be automated in
 the future) to get even more user-friendly types.
 
@@ -131,7 +131,7 @@ This is especially useful when there are many possible equivalences and you'd li
 but let DEVOID figure out the rest. See [Swap.v](/plugin/coq/Swap.v) for examples of this.
 
 To use a custom equivalence not at all supported by one of the four search procedures, like switching between unary and binary natural numbers,
-check out two examples [here](/plugin/coq/nonorn.v) and [here](https://github.com/uwplse/ornamental-search/blob/master/plugin/coq/playground/constr_refactor.v).
+check out two examples [here](/plugin/coq/nonorn.v) and [here](redacted).
 These examples set manual configuration and essentially skip the search procedure.
 We will document them soon!
 
@@ -261,7 +261,7 @@ Lift A B in f as g.
 ```
 
 You can also run `Preprocess` on an entire module; see [ListToVect.v](/plugin/coq/examples/ListToVect.v)
-for an example of this. See the [fix-to-elim](https://github.com/uwplse/coq-plugin-lib) plugin
+for an example of this. See the [fix-to-elim](redacted) plugin
 for more functionality for `Preprocess`.
 
 ##### User-Friendly Types
@@ -301,12 +301,9 @@ you would like to see supported so that we can prioritize accordingly.
 
 ### Known Issues
 
-Please see our GitHub [issues](https://github.com/uwplse/ornamental-search/issues) before reporting a bug
-(though please do report any bugs not listed there).
-
 One outstanding issue (an unimplemented optimization) has consequences for how we lift and unpack large
 constants compositionally. For now, for large constants, you should prefer lifting several times and then unpacking
-the result several times over iteratively lifting and unpacking. See [this issue](https://github.com/uwplse/ornamental-search/issues/44).
+the result several times over iteratively lifting and unpacking. See [this issue](redacted).
 
 There are also still some open questions about eta expansion and definitional equality. Practically, from a user's perspective,
 that means that lifting may sometimes fail with mysterious type errors for types that look almost but not quite correct.
@@ -510,9 +507,9 @@ Please also feel free to ask if you are confused about anything that the code do
     - [times.sed](/plugin/eval/times.sed): Script to format times
     - [together.sh](/plugin/eval/together.sh): Main case study script
   - [deps](/plugin/deps): Depedencies
-    - [fix-to-elim](/plugin/src/fix-to-elim): **Preprocessing** with the [fix-to-elim](https://github.com/uwplse/coq-plugin-lib) plugin
+    - [fix-to-elim](/plugin/src/fix-to-elim): **Preprocessing** with the [fix-to-elim](redacted) plugin
   - [src](/plugin/src): Source directory
-    - [coq-plugin-lib](/plugin/src/coq-plugin-lib): [Coq plugin library](https://github.com/uwplse/coq-plugin-lib)
+    - [coq-plugin-lib](/plugin/src/coq-plugin-lib): [Coq plugin library](redacted)
     - [lib](/plugin/src/lib): Internal library
     - [automation](/plugin/src/automation): Automation directory
       - [search](/plugin/src/automation/search): **Search**

--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@ proof repair plugin suite, and is included as a dependency of PUMPKIN PATCH
 starting with release 0.1.
 We call the current version of PUMPKIN PATCH with support for equivalences through DEVOID "PUMPKIN Pi."
 
-DEVOID began as the artifact for the ITP paper [Ornaments for Proof Reuse in Coq](http://tlringer.github.io/pdf/ornpaper.pdf), but has since been extended. A version of DEVOID that corresponds to the
-ITP camera-ready can be found in [this release](http://github.com/uwplse/ornamental-search/releases/tag/itp+equiv).
-
 Given two types A and B that are related in certain ways, DEVOID can search for
 and prove the relation between those types, then lift functions and proofs between them.
 The following relations are currently supported automatically:
@@ -526,7 +523,7 @@ Please also feel free to ask if you are confused about anything that the code do
       - [depelim.ml](/plugin/src/automation/depelim.ml) and [depelim.mli](/plugin/src/automation/depelim.mli): Automation for non-primitive projections
     - [cache](/plugin/src/cache): Caching ornaments and lifted terms
       - [caching.ml](/plugin/src/cache/caching.ml) and [caching.mli](/plugin/src/cache/caching.mli)
-    - [components](/plugin/src/components): Components in the style of [PUMPKIN PATCH](http://tlringer.github.io/pdf/pumpkinpaper.pdf)
+    - [components](/plugin/src/components): Components in the style of (redacted)
       - [abstraction.ml](/plugin/src/components/abstraction.ml) and [abstraction.mli](/plugin/src/components/abstraction.mli): 
       - [differencing.ml](differencing.ml) and [differencing.mli](/plugin/src/components/differencing.mli): 
       - [factoring.ml](/plugin/src/components/factoring.ml) and [factoring.mli](/plugin/src/components/factoring.mli): 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 This is DEVOID, a plugin for automatic discovery of and lifting across 
 certain equivalences between types in Coq.
-DEVOID is a part of the [PUMPKIN PATCH](https://github.com/uwplse/PUMPKIN-PATCH) 
-proof repair plugin suite, and is included as a dependency of PUMPKIN PATCH
-starting with release 0.1.
-We call the current version of PUMPKIN PATCH with support for equivalences through DEVOID "PUMPKIN Pi."
+DEVOID is a part of one of the author's past projects, a 
+proof repair plugin suite, and is included as a dependency of that project.
 
 Given two types A and B that are related in certain ways, DEVOID can search for
 and prove the relation between those types, then lift functions and proofs between them.

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ We used to use this command to measure the performance of `foo`:
 Eval vm_compute in foo.
 ```
 
-An ITP reviewer noted that this includes the amount of time to print `foo`. This is a lot of
+A reviewer noted that this includes the amount of time to print `foo`. This is a lot of
 overhead that clouds the usefulness of the data. The reviewer suggested writing:
 
 ```
@@ -557,5 +557,5 @@ If you are an expert in licensing, definitely let me know if this is wrong.
 
 Regardless, I would like CARROT to be used freely by anyone for any purpose.
 All I ask for is attribution, especially in any papers that you publish that use CARROT
-or any of its code. Please cite the ITP paper when referring to CARROT in those papers.
+or any of its code. Please cite (redacted) when referring to CARROT in those papers.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-This is DEVOID, a plugin for automatic discovery of and lifting across 
+This is CARROT, a plugin for automatic discovery of and lifting across 
 certain equivalences between types in Coq.
-DEVOID is a part of one of the author's past projects, a 
+CARROT is a part of one of the author's past projects, a 
 proof repair plugin suite, and is included as a dependency of that project.
 
-Given two types A and B that are related in certain ways, DEVOID can search for
+Given two types A and B that are related in certain ways, CARROT can search for
 and prove the relation between those types, then lift functions and proofs between them.
 The following relations are currently supported automatically:
 
@@ -16,31 +16,31 @@ swapping constructor order and renaming constructors
 4. **Escaping Sigma Types**: the type B (like `vector T n`) is the type A (like `{ s : sigT (vector T) & projT1 s = n}`) 
 escaping the sigma type
 
-In general, DEVOID can lift functions and proofs across **any equivalence that can be described by a configuration with a certain form**.
+In general, CARROT can lift functions and proofs across **any equivalence that can be described by a configuration with a certain form**.
 For change that don't fall into the above four buckets, you need to supply the configuration for that equivalence yourself.
 This is not yet documented here due to time constraints (I promise I will document it soon).
 For now, check out two examples: switching between unary and binary natural numbers [here](/plugin/coq/nonorn.v),
 and an easier refactoring of constructors [here](redacted).
 
-# Getting Started with DEVOID
+# Getting Started with CARROT
 
 This section of the README is a getting started guide for users.
 Please report any issues you encounter to GitHub issues, and please feel free to reach out with questions.
 
-## Building DEVOID
+## Building CARROT
 
-The only dependency you need to install yourself in order to use DEVOID is Coq 8.8. 
-DEVOID also depends on a
+The only dependency you need to install yourself in order to use CARROT is Coq 8.8. 
+CARROT also depends on a
 [Coq plugin library](redacted) which is included
 as a submodule automatically in the build script,
-and on the [fix-to-elim](redacted) plugin, which is also included. To build DEVOID, run these commands:
+and on the [fix-to-elim](redacted) plugin, which is also included. To build CARROT, run these commands:
 
 ```
 cd plugin
 ./build.sh
 ```
 
-## Using DEVOID
+## Using CARROT
 
 For an overview of how to use the tool, see [Example.v](/plugin/coq/examples/Example.v)
 and [minimal_records.v](/plugin/coq/minimal_records.v).
@@ -51,9 +51,9 @@ At a high level, there are two main commands: `Find ornament` to search for equi
 and `Lift` (or `Repair` for tactic support) to lift along those equivalences. `Find ornament` supports two additional options
 to increase user confidence and to make the functions that it generates more useful.
 If you skip running the `Find ornament` command and just run `Lift`,
-then DEVOID will run `Find ornament` for you automatically first.
+then CARROT will run `Find ornament` for you automatically first.
 
-In addition, there are a few commands that help make DEVOID more useful: `Preprocess`
+In addition, there are a few commands that help make CARROT more useful: `Preprocess`
 for pattern matching and fixpoint support, and `Unpack` to help recover more user-friendly types.
 The `Preprocess` command comes from our plugin
 [fix-to-elim](redacted).
@@ -91,14 +91,14 @@ By default, these options are disabled.
 Together, setting these two options tells `Find ornament` to prove that its outputs are correct.
 
 ```
-Set DEVOID search prove coherence.
+Set CARROT search prove coherence.
 ```
 
 For algebraic ornaments, this option tells `Find ornament` to additionally generate a proof `A_to_B_coh` that shows that
 `A_to_B_index` computes the left projection of applying `A_to_B`.
 
 ```
-Set DEVOID search prove equivalence.
+Set CARROT search prove equivalence.
 ```
 
 This option tells `Find ornament` to generate proofs `A_to_B_section` and `A_to_B_retraction` that
@@ -121,14 +121,14 @@ You can also use this to substitute in a different equivalence for an existing o
 are some restrictions here on what is possible. See [ListToVectCustom.v](/plugin/coq/examples/ListToVectCustom.v)
 for more information.
 
-You can also skip one of promote or forget, provide just one, and let DEVOID find the other for certain search procedures, for example:
+You can also skip one of promote or forget, provide just one, and let CARROT find the other for certain search procedures, for example:
 
 ```
 Save ornament A B { promote = f }.
 ```
 
 This is especially useful when there are many possible equivalences and you'd like to use a particular one,
-but let DEVOID figure out the rest. See [Swap.v](/plugin/coq/Swap.v) for examples of this.
+but let CARROT figure out the rest. See [Swap.v](/plugin/coq/Swap.v) for examples of this.
 
 To use a custom equivalence not at all supported by one of the four search procedures, like switching between unary and binary natural numbers,
 check out two examples [here](/plugin/coq/nonorn.v) and [here](redacted).
@@ -137,17 +137,17 @@ We will document them soon!
 
 ##### Ambiguity 
 
-Sometimes, DEVOID finds multiple possible equivalences. With swapping constructors in particular, there can
+Sometimes, CARROT finds multiple possible equivalences. With swapping constructors in particular, there can
 be an exponential number of possible equivalences.
 
-In the case of ambiguity, DEVOID presents up to the first 50 possible
+In the case of ambiguity, CARROT presents up to the first 50 possible
 options for the user (in a smart order), presents this as an error, and gives instructions for the user to
 provide more information to `Find ornament` in the next iteration. If the equivalence you want is not in the
 first 50 candidates, please use `Save ornament`. See [Swap.v](/plugin/coq/Swap.v) for examples of both of these.
 
 ##### Tactic Support
 
-DEVOID produces tactic suggestions for all proofs that `Find ornament` finds.
+CARROT produces tactic suggestions for all proofs that `Find ornament` finds.
 These are experimental, especially with dependent types, but may help you work with tactic proofs about equivalences.
 
 #### Lift and Repair
@@ -162,7 +162,7 @@ Lift A B in f as g.
 ``` 
 
 This command lifts a function or proof `f` along the discovered relation.
-DEVOID must be able to find an ornament between `A` and `B` for this
+CARROT must be able to find an ornament between `A` and `B` for this
 command to work. If you have already called `Find ornament` on `A` and `B`,
 it will use the discovered ornament; otherwise, it will search for an
 ornament first.
@@ -200,12 +200,12 @@ These tactic suggestions are experimental, but may help you with workflow integr
 
 ##### Prettier Types
 
-By default, DEVOID lets Coq infer the types of lifted terms. You can 
-instead tell DEVOID to lift the types (these are typically prettier)
+By default, CARROT lets Coq infer the types of lifted terms. You can 
+instead tell CARROT to lift the types (these are typically prettier)
 if you set the following function:
 
 ```
-Set DEVOID lift type.
+Set CARROT lift type.
 ```
 
 ##### Opaque Terms
@@ -218,7 +218,7 @@ Lift A B in f as g { opaque constant1 constant2 ... }.
 ``` 
 
 This can make lifting much faster.
-It is **strongly advisable** to do this for certain terms that you know DEVOID
+It is **strongly advisable** to do this for certain terms that you know CARROT
 should never reduce.
 However, this can also cause unpredictable errors if your assumption is incorrect,
 so be careful about your assumption.
@@ -234,11 +234,11 @@ You can find an example of this in [more_records.v](/plugin/coq/more_records.v).
 
 ##### Caching
 
-DEVOID by default caches all lifted terms it encounters as it goes in order to save time.
+CARROT by default caches all lifted terms it encounters as it goes in order to save time.
 You can disable this if you'd like by running this command:
 
 ```
-Unset DEVOID smart cache. 
+Unset CARROT smart cache. 
 ```
 
 #### Additional Functionality
@@ -280,7 +280,7 @@ that are very user friendly, check out the methodology in
 set the following option:
 
 ```
-Set DEVOID search smart eliminators.
+Set CARROT search smart eliminators.
 ```
 
 This generates a useful induction principle. Using that induction princple and composing
@@ -289,7 +289,7 @@ particular index, with much nicer type signatures.
 
 ### Assumptions
 
-DEVOID makes some assumptions about your terms and types for now (described in Section 3 of the paper).
+CARROT makes some assumptions about your terms and types for now (described in Section 3 of the paper).
 [Assumptions.v](/plugin/coq/examples/Assumptions.v) describes these assumptions in more detail
 and gives examples of unsupported terms and types.
 Note that the assumptions for records and tuples are not yet documented, since
@@ -397,7 +397,7 @@ Run the following script:
 ```
 
 The script takes a while, as it runs each function ten times each
-on large data both for DEVOID and for EFF.
+on large data both for CARROT and for EFF.
 When it is done, check the `results` folder for the median runtimes as well as the size of reduced functions.
 This also does a sanity check to make sure both versions of the code produce the same output.
 It does not yet try to reduce the proof of `pre_permutes` using EFF,
@@ -425,8 +425,8 @@ This should take a while (how long depends on your architecture) and produce a v
 ## Understanding the Case Study Code
 
 The code for the case study is in the [eval](/plugin/eval) folder.
-The case study uses the same exact input datatypes for both DEVOID and EFF,
-copying and pasting in the inputs, lifted functions, and equivalences DEVOID produces to run on the dependencies of EFF.
+The case study uses the same exact input datatypes for both CARROT and EFF,
+copying and pasting in the inputs, lifted functions, and equivalences CARROT produces to run on the dependencies of EFF.
 The reasons for copying the inputs are that EFF has different
 Coq dependencies, so the base functions perform differently. In addition, lifting constants with EFF additionally slows down 
 performance, and we would like to control for only the performance of lifted functions, which is easiest to understand.
@@ -462,11 +462,11 @@ Transparency is very important to me and my coauthors. My goal is not just to pr
 but also to demonstrate ideas that other people can use in their tools.
 
 Some information for transparency is in the paper:
-Section 4 discusses the core algorithms that DEVOID implements, and
+Section 4 discusses the core algorithms that CARROT implements, and
 section 5 discusses a sample of implementation challenges.
 
 This part of the README is here to complement that. It describes the structure of the code a bit. It should also help if you are interested in contributing
-to DEVOID, or if you are interested in using some of the libraries from DEVOID in your code.
+to CARROT, or if you are interested in using some of the libraries from CARROT in your code.
 
 ## Understanding the Code
 
@@ -479,7 +479,7 @@ Please also feel free to ask if you are confused about anything that the code do
   - [test.sh](/plugin/coq/test.sh): Test script
   - [coq](/plugin/coq): Tests and paper examples
     - [examples](/plugin/coq/examples): Paper examples (see paper examples section of this document for details)
-    - [playground](/plugin/coq/playground): Preliminary thoughts on useful theory for later extensions to DEVOID
+    - [playground](/plugin/coq/playground): Preliminary thoughts on useful theory for later extensions to CARROT
     - [Indtype.v](/plugin/coq/Indtype.v): Lifting tests for inductive relations
     - [Infrastructure.v](/plugin/coq/Infrastructure.v): Testing infrastructure
     - [ShouldFail.v](/plugin/coq/ShouldFail.v): Tests that should currently fail
@@ -503,7 +503,7 @@ Please also feel free to ask if you are confused about anything that the code do
     - [Makefile](/plugin/eval/Makefile)
     - [cast.v](/plugin/eval/cast.v)
     - [lemmas.v](/plugin/eval/lemmas.v)
-    - [main.v](/plugin/eval/main.v): Main DEVOID case study code
+    - [main.v](/plugin/eval/main.v): Main CARROT case study code
     - [times.sed](/plugin/eval/times.sed): Script to format times
     - [together.sh](/plugin/eval/together.sh): Main case study script
   - [deps](/plugin/deps): Depedencies
@@ -528,11 +528,11 @@ Please also feel free to ask if you are confused about anything that the code do
     - [options.ml](/plugin/src/options.ml) and [options.mli](/plugin/src/options.mli): Definitions of and access to options
     - [ornamental.ml4](/plugin/src/ornamental.ml4): **Top-level source file**
     - [ornaments.mlpack](/plugin/src/ornaments.mlpack)
-  - [theories](/plugin/theories): DEVOID theories
+  - [theories](/plugin/theories): CARROT theories
     - [Adjoint.v](/plugin/theories/Adjoint.v): Turning equivalences into adjoint equivalences
     - [Prod.v](/plugin/theories/Prod.v): Preprocessed projections of pairs
     - [Eliminators.v](/plugin/theories/Eliminators.v): **Generalized smart eliminators for user-friendly types**
-    - [Ornaments.v](/plugin/theories/Ornaments.v): Loader theory for DEVOID
+    - [Ornaments.v](/plugin/theories/Ornaments.v): Loader theory for CARROT
     - [Unpack.v](/plugin/theories/Unpack.v): **Unpacking terms** (Ltac tactic)
 * [.gitignore](/.gitignore)
 * [README.md](/README.md)
@@ -545,17 +545,17 @@ The test script in the [plugin](/plugin) directory runs all of the regression te
 ./test.sh
 ```
 
-After making a change to DEVOID, you should always run this. You should
+After making a change to CARROT, you should always run this. You should
 also run the case study scripts to check performance.
 
 ## Licensing and Attribution
 
-DEVOID is MIT licensed, since I have a very strong preference for the MIT license and
+CARROT is MIT licensed, since I have a very strong preference for the MIT license and
 since I believe I do not need to use Coq's LGPL when writing language plugins.
 This interpretation might be wrong, though, so I suppose you should tread lightly.
 If you are an expert in licensing, definitely let me know if this is wrong.
 
-Regardless, I would like DEVOID to be used freely by anyone for any purpose.
-All I ask for is attribution, especially in any papers that you publish that use DEVOID
-or any of its code. Please cite the ITP paper when referring to DEVOID in those papers.
+Regardless, I would like CARROT to be used freely by anyone for any purpose.
+All I ask for is attribution, especially in any papers that you publish that use CARROT
+or any of its code. Please cite the ITP paper when referring to CARROT in those papers.
 

--- a/plugin/build.sh
+++ b/plugin/build.sh
@@ -5,7 +5,7 @@ echo "building dependencies"
 cd deps/fix-to-elim/plugin
 ./build.sh
 cd ../../..
-echo "building DEVOID"
+echo "building CARROT"
 
 coq_makefile -f _CoqProject -o Makefile
 make clean && make && make install

--- a/plugin/coq/ShouldFail.v
+++ b/plugin/coq/ShouldFail.v
@@ -115,7 +115,7 @@ Qed.
  * This fails:
  * Find ornament list vector_int as orn_list_vectorint.
  *
- * For this to pass, we really need to chain it with PUMPKIN, because what
+ * For this to pass, we really need to chain it with (redacted), because what
  * is happening is we first need to find the patch that gets us from list
  * to vector, and then we need to get from that indexing function
  * to Z by searching for a patch. This is really cool.

--- a/plugin/coq/Swap.v
+++ b/plugin/coq/Swap.v
@@ -1,5 +1,5 @@
 (*
- * DEVOID supports swapping and renaming constructors!
+ * CARROT supports swapping and renaming constructors!
  * Here are some examples.
  *)
 

--- a/plugin/coq/TestLift.v
+++ b/plugin/coq/TestLift.v
@@ -525,7 +525,7 @@ Proof. reflexivity. Defined.
 (* --- Regressing the bug Nate caught with LIFT-PACK and variables --- *)
 
 (*
- * See: https://github.com/uwplse/ornamental-search/issues/14
+ * See: redacted
  *)
 
 Lemma tl_ok:

--- a/plugin/coq/examples/Assumptions.v
+++ b/plugin/coq/examples/Assumptions.v
@@ -210,7 +210,7 @@ Fail Find ornament list vector_int as orn_list_vectorint.
  * that gets us from nat to Z first. And for some terms, this function
  * might be less obvious.
  *
- * The way to loosen this restriction a bit is to chain DEVOID with (redacted).
+ * The way to loosen this restriction a bit is to chain CARROT with (redacted).
  *)
 
 (* --- New hypotheses must be exactly the new index of the recursive references --- *)

--- a/plugin/coq/examples/Assumptions.v
+++ b/plugin/coq/examples/Assumptions.v
@@ -210,11 +210,7 @@ Fail Find ornament list vector_int as orn_list_vectorint.
  * that gets us from nat to Z first. And for some terms, this function
  * might be less obvious.
  *
- * The way to loosen this restriction a bit is to chain DEVOID with PUMPKIN PATCH.
- * Finding the relationship between vector and vector_int is very, very much
- * a PUMPKIN PATCH problem in the original style of PUMPKIN PATCH. I am very
- * excited to do this as part of my thesis work, and I was very excited when
- * I found this problem to begin with. But it's a hard problem.
+ * The way to loosen this restriction a bit is to chain DEVOID with (redacted).
  *)
 
 (* --- New hypotheses must be exactly the new index of the recursive references --- *)

--- a/plugin/coq/examples/Example.v
+++ b/plugin/coq/examples/Example.v
@@ -1,9 +1,5 @@
 (*
- * Section 2 Example from the ITP 2019 paper.
- *
- * NOTE: This has changed a lot since the ITP paper! I have updated this file
- * to reflect the latest automation. To see the original ITP version,
- * take a look at the state of this file in the ITP release.
+ * Section 2 Example from [redacted].
  *)
 
 Add LoadPath "coq/examples".
@@ -134,7 +130,7 @@ Check zip_with_is_zipV_p.
  * a nice custom eliminator to make this easier.
  *
  * Let's start by proving the length invariants
- * (these were also proven by the human for ITP 2019):
+ * (these were also proven by the human for [redacted]):
  *)
 Module hs_to_coq_lengths'.
 
@@ -182,7 +178,7 @@ Preprocess Module hs_to_coq_lengths' as hs_to_coq_lengths { opaque Datatypes Log
  * Once we have the length proofs, we write the proofs
  * about { l : list T & length l = n }. To do this,
  * it's useful to have a nice induction principle,
- * which CARROT generated since we set the "smart elims" option (new since ITP 2019)
+ * which CARROT generated since we set the "smart elims" option (new since [redacted])
  * (the name of this will always be the name of your promote function
  * followed by _rect):
  *)
@@ -276,7 +272,7 @@ End packed_list.
 
 (*
  * Now we can get from that to { s : sigT (vector T) & projT1 s = n} by lifting from
- * lists to vectors (new since ITP 2019).
+ * lists to vectors (new since [redacted]).
  *
  * Rather than preprocess here, we just set terms that use pattern matching to
  * opaque for efficiency. We use Lift intead of Repair when tactics don't matter.

--- a/plugin/coq/examples/Example.v
+++ b/plugin/coq/examples/Example.v
@@ -76,7 +76,7 @@ Set DEVOID search prove equivalence.
 Set DEVOID lift type.
 
 (*
- * This option tells DEVOID to generate an induction principle that
+ * This option tells CARROT to generate an induction principle that
  * will be useful later:
  *)
 Set DEVOID search smart eliminators.
@@ -182,14 +182,14 @@ Preprocess Module hs_to_coq_lengths' as hs_to_coq_lengths { opaque Datatypes Log
  * Once we have the length proofs, we write the proofs
  * about { l : list T & length l = n }. To do this,
  * it's useful to have a nice induction principle,
- * which DEVOID generated since we set the "smart elims" option (new since ITP 2019)
+ * which CARROT generated since we set the "smart elims" option (new since ITP 2019)
  * (the name of this will always be the name of your promote function
  * followed by _rect):
  *)
 Definition packed_list_rect := hs_to_coqV_p.list_to_t_rect.
 Check packed_list_rect.
 (*
- * TECHNICAL NOTE: DEVOID for now makes some assumptions
+ * TECHNICAL NOTE: CARROT for now makes some assumptions
  * about the format here. Try not to run "induction" on terms of type
  * { l : list T & length l = n } directly, and instead try to 
  * use this induction principle. I'm working on relaxing this
@@ -293,7 +293,7 @@ Check packed_vector.zip_with_is_zip.
  * Finally, we can get from { s : sigT (vector T) & projT1 s = n} to unpacked vectors
  * at the index we want very easily.
  *
- * First we define a constant for { s : sigT (vector T) & projT1 s = n}, since DEVOID needs
+ * First we define a constant for { s : sigT (vector T) & projT1 s = n}, since CARROT needs
  * this for caching.
  *)
 Definition packed T n := { s : sigT (vector T) & projT1 s = n}.
@@ -316,7 +316,7 @@ Check uf.zip_with_is_zip.
 
 (*
  * TECHNICAL NOTE: For this particular example, interestingly, doing these by hand
- * without DEVOID, it's possible to construct functions such that the proof
+ * without CARROT, it's possible to construct functions such that the proof
  * of uf.zip_with_is_zipV goes through by reflexivity. However, these
  * are not the analogues of the functions included in the hs_to_coq module
  * (note that the proof using reflexivity does not work for them either).
@@ -335,7 +335,7 @@ Definition BVand' {n : nat} (v1 : vector bool n) (v2 : vector bool n) : vector b
  * We can use suggested tactics to get tactic scripts, but (as noted)
  * since they struggle with dependent types, we need to do a _lot_ of tweaking
  * right now. Still, let's do it using the suggested tactics and the terms
- * DEVOID has generated. These won't give exactly the same proof terms,
+ * CARROT has generated. These won't give exactly the same proof terms,
  * but we're OK with that.
  *
  * For zip:

--- a/plugin/coq/examples/Example.v
+++ b/plugin/coq/examples/Example.v
@@ -92,7 +92,7 @@ Repair Module list vector in hs_to_coq as hs_to_coqV_p.
  * we modify the suggestion in the paper.
  *
  * Please also note this regression bug that makes terms and types uglier than usual
- * (though still correct): https://github.com/uwplse/pumpkin-pi/issues/84
+ * (though still correct): redacted
  *)
 
 (*

--- a/plugin/coq/examples/Intro.v
+++ b/plugin/coq/examples/Intro.v
@@ -1,5 +1,5 @@
 (*
- * Section 1 Example, using DEVOID
+ * Section 1 Example, using CARROT
  *)
 
 Require Import Vector.

--- a/plugin/coq/examples/ListToVect.v
+++ b/plugin/coq/examples/ListToVect.v
@@ -58,5 +58,5 @@ Lift Module list vector in List' as Vector' { opaque (* ignore these, just for s
 (*
  * There are still two proofs (`partition_length` and `elements_in_partition`)
  * that fail to lift above, due to implementation bugs.
- * See: https://github.com/uwplse/ornamental-search/issues/32
+ * See: redacted
  *)

--- a/plugin/coq/examples/ListToVectCustom.v
+++ b/plugin/coq/examples/ListToVectCustom.v
@@ -60,7 +60,7 @@ existT (fun H : nat => vector A H) (length l)
 (*
  * The correctness condition is that these also form an equivalence with the same
  * coherence properties. We don't need to prove this, however. We can just tell
- * DEVOID to use our equivalence. (Use at your own risk! If you pick something that isn't an equivalence,
+ * CARROT to use our equivalence. (Use at your own risk! If you pick something that isn't an equivalence,
  * lifting will fail with confusing type errors.)
  *)
 Save ornament list vector { promote = ltv }.

--- a/plugin/coq/examples/Search.v
+++ b/plugin/coq/examples/Search.v
@@ -69,9 +69,9 @@ Notation forget l := (ltv_inv _ l).
 
 (*
  * Since we set the "prove coherence" and "prove equivalence" options,
- * DEVOID generated coherence, section, and retraction proofs. Here I
+ * CARROT generated coherence, section, and retraction proofs. Here I
  * simply restate them and show that the generated terms are correct.
- * These automatically generated proofs show that the components DEVOID
+ * These automatically generated proofs show that the components CARROT
  * found form the ornamental promotion isomorphism between lists and vectors.
  *
  * Coherence follows by construction, while section and retraction each

--- a/plugin/coq/minimal_records.v
+++ b/plugin/coq/minimal_records.v
@@ -86,7 +86,7 @@ Lift Module Generated'.output Handwritten'.output in Temp1 as Handwritten''.
  * with the bigger one and then tell DEVOID to treat the lifted projections as opaque.
  * Really interesting WIP on handling this better without so much work for the user.
  *
- * See: https://taliasplse.wordpress.com/2020/02/02/automating-transport-with-univalent-e-graphs/
+ * See: [redacted]
  *)
 
 (*

--- a/plugin/coq/minimal_records.v
+++ b/plugin/coq/minimal_records.v
@@ -83,7 +83,7 @@ Lift Module Generated'.output Handwritten'.output in Temp1 as Handwritten''.
  * If you lift in the opposite order, for op, you get something well-typed but with
  * a type you don't even want. So for now when one type definition you lift along
  * is a subterm of another type definition you lift along, you will need to start
- * with the bigger one and then tell DEVOID to treat the lifted projections as opaque.
+ * with the bigger one and then tell CARROT to treat the lifted projections as opaque.
  * Really interesting WIP on handling this better without so much work for the user.
  *
  * See: [redacted]

--- a/plugin/eval/equiv4free/main.v
+++ b/plugin/eval/equiv4free/main.v
@@ -177,7 +177,7 @@ Module CaseStudy (Elem : Comparable).
     (* --- Begin inputs --- *)
 
     (*
-     * We import these from DEVOID, that way we can measure the performance difference of
+     * We import these from CARROT, that way we can measure the performance difference of
      * only the lifted functions, controlling for the performance of lifted inputs (which is
      * slower in EFF) without clouding the results.
      *)
@@ -305,7 +305,7 @@ Module CaseStudy (Elem : Comparable).
       rewrite Equiv_tree_id. cbn. eapply Equiv_id.
     Defined.
 
-    (* --- Begin auto-generated equivalences from DEVOID --- *)
+    (* --- Begin auto-generated equivalences from CARROT --- *)
 
     (* EQUIV orn_size_index *)
     (* EQUIV orn_size *)
@@ -313,7 +313,7 @@ Module CaseStudy (Elem : Comparable).
     (* EQUIV orn_size_section *)
     (* EQUIV orn_size_retraction *)
  
-    (* --- End auto-generated equivalences from DEVOID --- *)
+    (* --- End auto-generated equivalences from CARROT --- *)
 
     Instance IsEquiv_orn_size : IsEquiv orn_size.
     Proof.
@@ -337,10 +337,10 @@ Module CaseStudy (Elem : Comparable).
 
     Definition orn_size_coh t : orn_size_inv (orn_size t) = t := e_sect orn_size t.
 
-    (* --- Begin automatically generated lifted inputs from DEVOID --- *)
+    (* --- Begin automatically generated lifted inputs from CARROT --- *)
 
     (*
-     * We import these from DEVOID, that way we can measure the performance difference of
+     * We import these from CARROT, that way we can measure the performance difference of
      * only the lifted functions, controlling for the performance of lifted inputs (which is
      * slower in EFF) without clouding the results.
      *)
@@ -367,7 +367,7 @@ Module CaseStudy (Elem : Comparable).
     (* INPUT tree80000-sized *)
     (* INPUT tree100000-sized *)
 
-    (* --- End automatically generated lifted inputs from DEVOID --- *)
+    (* --- End automatically generated lifted inputs from CARROT --- *)
 
     (* 38 LoC in normal form *)
     Definition preorder' : {n:nat & tree n} -> list Elem.t := ↑ Base.preorder.
@@ -517,7 +517,7 @@ Module CaseStudy (Elem : Comparable).
       econstructor. cbn. intros t t'. unfold univalent_transport. rewrite Equiv_bst_id. cbn. eapply Equiv_id.
     Defined.
 
-    (* --- Begin auto-generated equivalences from DEVOID --- *)
+    (* --- Begin auto-generated equivalences from CARROT --- *)
 
     (* EQUIV __orn_order_index *)
     (* EQUIV __orn_order *)
@@ -535,7 +535,7 @@ Module CaseStudy (Elem : Comparable).
     (* EQUIV orn_order_section *)
     (* EQUIV orn_order_retraction *)
  
-    (* --- End auto-generated equivalences from DEVOID --- *)
+    (* --- End auto-generated equivalences from CARROT --- *)
  
    Instance IsEquiv___orn_order : IsEquiv __orn_order.
     Proof.
@@ -597,10 +597,10 @@ Module CaseStudy (Elem : Comparable).
       - apply Canonical_eq_gen.
     Defined.
 
-    (* --- Begin automatically generated lifted inputs from DEVOID --- *)
+    (* --- Begin automatically generated lifted inputs from CARROT --- *)
 
     (*
-     * We import these from DEVOID, that way we can measure the performance difference of
+     * We import these from CARROT, that way we can measure the performance difference of
      * only the lifted functions, controlling for the performance of lifted inputs (which is
      * slower in EFF) without clouding the results.
      *)
@@ -648,7 +648,7 @@ Module CaseStudy (Elem : Comparable).
     (* INPUT tree10000-bst *)
     (* INPUT tree100000-bst *)
 
-    (* --- End automatically generated lifted inputs from DEVOID --- *)
+    (* --- End automatically generated lifted inputs from CARROT --- *)
 
     (* For consistency, follow the same process *)
     Definition __preorder'  : {lo:Elem.t & __bst lo} -> list Elem.t := ↑ Base.preorder.
@@ -749,7 +749,7 @@ Module CaseStudy (Elem : Comparable).
       rewrite Equiv_avl_id. cbn. eapply Equiv_id.
     Defined.
 
-    (* --- Begin auto-generated equivalences from DEVOID --- *)
+    (* --- Begin auto-generated equivalences from CARROT --- *)
 
     (* EQUIV _orn_balance_index *)
     (* EQUIV _orn_balance *)
@@ -762,7 +762,7 @@ Module CaseStudy (Elem : Comparable).
     (* EQUIV orn_balance_section *)
     (* EQUIV orn_balance_retraction *)
  
-    (* --- End auto-generated equivalences from DEVOID --- *)
+    (* --- End auto-generated equivalences from CARROT --- *)
 
     Instance IsEquiv__orn_balance (lo hi : Elem.t) (ord : bool) : IsEquiv (_orn_balance lo hi ord).
     Proof.
@@ -808,10 +808,10 @@ Module CaseStudy (Elem : Comparable).
       - apply Canonical_eq_gen.
     Defined.
 
-    (* --- Begin automatically generated lifted inputs from DEVOID --- *)
+    (* --- Begin automatically generated lifted inputs from CARROT --- *)
 
     (*
-     * We import these from DEVOID, that way we can measure the performance difference of
+     * We import these from CARROT, that way we can measure the performance difference of
      * only the lifted functions, controlling for the performance of lifted inputs (which is
      * slower in EFF) without clouding the results.
      *)
@@ -866,7 +866,7 @@ Module CaseStudy (Elem : Comparable).
     (* INPUT tree10000-avl *)
     (* INPUT tree100000-avl *)
 
-    (* --- End automatically generated lifted inputs from DEVOID --- *)
+    (* --- End automatically generated lifted inputs from CARROT --- *)
 
     Definition _preorder' lo hi ord : {n : nat & _avl lo hi ord n} -> list Elem.t :=
       ↑ (@Ordered.preorder lo hi ord).

--- a/plugin/eval/equiv4free/prepermutes.sh
+++ b/plugin/eval/equiv4free/prepermutes.sh
@@ -26,7 +26,7 @@ mkdir ../out/equivalences
 mkdir ../out/normalized
 cp main.v main2.v
 
-# Remake DEVOID case study code exactly once, to print terms
+# Remake CARROT case study code exactly once, to print terms
 cd ..
 make clean
 make

--- a/plugin/eval/together.sh
+++ b/plugin/eval/together.sh
@@ -48,10 +48,10 @@ mkdir results/search
 cp main.v main2.v
 cp equiv4free/main.v equiv4free/main2.v
 
-# Set DEVOID case study code to print regular terms instead of computed ones
+# Set CARROT case study code to print regular terms instead of computed ones
 sed -i "s/Eval compute in/Print/" main2.v
 
-# Remake DEVOID case study code exactly once, to print terms
+# Remake CARROT case study code exactly once, to print terms
 make clean
 make together
 

--- a/plugin/src/automation/lift/lift.ml
+++ b/plugin/src/automation/lift/lift.ml
@@ -364,7 +364,7 @@ let do_lift_ind env sigma l typename suffix ind ignores is_lift_module =
                let n = Names.Label.to_id (Names.Constant.label p) in
                let def = Defutils.define_term n sigma p_lifted true in
                Feedback.msg_info
-                 (Pp.str (Printf.sprintf "DEVOID generated %s" (Names.Id.to_string n)));
+                 (Pp.str (Printf.sprintf "CARROT generated %s" (Names.Id.to_string n)));
                def))
           r.s_PROJ
       in

--- a/plugin/src/automation/lift/liftrules.ml
+++ b/plugin/src/automation/lift/liftrules.ml
@@ -37,12 +37,12 @@ open Indexing
  *    we just return the cached lifted term. This carries the cached
  *    lifted term.
  *
- * 3. OpaqueConstant: When a user uses the opaque option for DEVOID for a given
+ * 3. OpaqueConstant: When a user uses the opaque option for CARROT for a given
  *    constant, we do not delta-reduce that constant.
  *    Note that this is different from Coq's notion of "opaque"; we may
  *    delta-reduce constants marked as opaque to the rest of Coq, and we may
  *    consider a constant opaque when Coq does not. It depends only on the
- *    user setting this particular option for DEVOID.
+ *    user setting this particular option for CARROT.
  *
  * 4. SimplifyProjectId: When we see projections of lifted eta-expanded identity
  *    terms (for example, projT1 (existT ...)), we reduce eagerly rather than
@@ -117,9 +117,9 @@ type lift_rule =
 (* --- Termination conditions --- *)
 
 (*
- * DEVOID supports some equivalences where the the type B refers in some
+ * CARROT supports some equivalences where the the type B refers in some
  * way to the type A. Work support these equivalences is preliminary,
- * but the way that DEVOID currently handles this is by threading the
+ * but the way that CARROT currently handles this is by threading the
  * history of the lifting operation through each recursive call.
  * When appropriate, based on the history, for certain rules,
  * certain termination conditions fire. If those conditions fire, we

--- a/plugin/src/automation/search/smartelim.ml
+++ b/plugin/src/automation/search/smartelim.ml
@@ -17,7 +17,7 @@ open Equtils
 open Nameutils
 
 (*
- * If the appropriate option is set, DEVOID generates useful "smart eliminators"
+ * If the appropriate option is set, CARROT generates useful "smart eliminators"
  * in addition to the equivalences it discovers. For example, for algebraic
  * ornaments, it generates and automatically lifts a useful eliminator over
  * { a : A & indexer a = i_b } that helps the user combine proofs about A and

--- a/plugin/src/automation/search/smartelim.mli
+++ b/plugin/src/automation/search/smartelim.mli
@@ -6,7 +6,7 @@ open Lifting
 open Names
 
 (*
- * If the appropriate option is set, DEVOID generates useful "smart eliminators"
+ * If the appropriate option is set, CARROT generates useful "smart eliminators"
  * in addition to the equivalences it discovers. For example, for algebraic
  * ornaments, it generates and automatically lifts a useful eliminator over
  * { a : A & indexer a = i_b } that helps the user combine proofs about A and

--- a/plugin/src/frontend.ml
+++ b/plugin/src/frontend.ml
@@ -57,10 +57,10 @@ let define_print ?typ n trm sigma =
         define_term n sigma trm true
     in
     Feedback.msg_info
-      (str (Printf.sprintf "DEVOID generated %s" (Id.to_string n)));
+      (str (Printf.sprintf "CARROT generated %s" (Id.to_string n)));
     def
   with Evarutil.Uninstantiated_evar _ ->
-    CErrors.user_err (str "DEVOID does not fully support implicit arguments")
+    CErrors.user_err (str "CARROT does not fully support implicit arguments")
 
 let suggest_tactic_script env trm_ref opts sigma =
   let trm = match trm_ref with
@@ -367,7 +367,7 @@ let lift_inductive_by_ornament env sigma n s l c_old ignores is_lift_module =
     let ind, _ = destInd c_old in
     let ind' = do_lift_ind env sigma l n s ind ignores is_lift_module in
     let env' = Global.env () in
-    Feedback.msg_info (str "DEVOID generated " ++ pr_inductive env' ind');
+    Feedback.msg_info (str "CARROT generated " ++ pr_inductive env' ind');
     ind'
   with
   | PretypeError (env, sigma, err) ->

--- a/plugin/src/lib/ornerrors.ml
+++ b/plugin/src/lib/ornerrors.ml
@@ -102,7 +102,7 @@ let workaround suggestions =
 (* --- Suggestion to read the FAQ --- *)
 
 let read_faq =
-  Pp.str "Please see the README in uwplse/ornamental-search for more information."
+  Pp.str "Please see the README in redacted for more information."
 
 (* --- Reasons to cut an issue --- *)
 
@@ -114,7 +114,7 @@ let cut_issue reasons =
   Pp.seq
     [Pp.str "If ";
      Pp.prlist_with_sep (fun _ -> Pp.str ", or if ") id reasons;
-     Pp.str ", then please cut an issue in the uwplse/ornamental-search repository."]
+     Pp.str ", then please cut an issue in the [redacted] repository."]
 
 (* --- Putting these together --- *)
     

--- a/plugin/src/lib/ornerrors.ml
+++ b/plugin/src/lib/ornerrors.ml
@@ -28,7 +28,7 @@ let err_save_ornament = Pp.str "Failed to save ornament."
 
 let err_unexpected_change expected_kind =
   Pp.seq
-    [Pp.str "DEVOID expected an ";
+    [Pp.str "CARROT expected an ";
      Pp.str expected_kind;
      Pp.str "."]
 
@@ -41,7 +41,7 @@ let err_opaque_not_constant qid =
 
 let err_type env sigma err =
   Pp.seq
-    [Pp.str "DEVOID tried to produce a term that is not well-typed. ";
+    [Pp.str "CARROT tried to produce a term that is not well-typed. ";
      Pp.str "Coq gave us this scary looking error:\n";
      Pp.fnl ();
      explain_pretype_error env sigma err;
@@ -68,7 +68,7 @@ let err_ambiguous_swap env num_solutions swap_maps sigma =
        Pp.fnl ()]
   in
   Pp.seq
-    [Pp.str "DEVOID found ";
+    [Pp.str "CARROT found ";
      Pp.str num_solutions;
      Pp.str " possible mappings for constructors. ";
      Pp.str "Showing up to the first 50:";
@@ -76,7 +76,7 @@ let err_ambiguous_swap env num_solutions swap_maps sigma =
      Pp.seq (List.mapi print_swap_map swap_maps);
      Pp.fnl ();
      Pp.str "Please choose the mapping you'd like to use. ";
-     Pp.str "Then, pass that to DEVOID by calling `Find ornament` again. ";
+     Pp.str "Then, pass that to CARROT by calling `Find ornament` again. ";
      Pp.str "For example: `Find ornament old new { mapping 0 }`. ";
      Pp.str "If the mapping you want is not in the 50 shown, ";
      Pp.str "please pass the mapping to `Save ornament` instead."]

--- a/plugin/src/options.ml
+++ b/plugin/src/options.ml
@@ -1,5 +1,5 @@
 
-(* --- Options for DEVOID --- *)
+(* --- Options for CARROT --- *)
 
 (*
  * Prove the coherence property of the algebraic promotion isomorphism
@@ -8,8 +8,8 @@
 let opt_search_coh = ref (false)
 let _ = Goptions.declare_bool_option {
   Goptions.optdepr = false;
-  Goptions.optname = "Generate a proof of coherence in search for DEVOID";
-  Goptions.optkey = ["DEVOID"; "search"; "prove"; "coherence"];
+  Goptions.optname = "Generate a proof of coherence in search for CARROT";
+  Goptions.optkey = ["CARROT"; "search"; "prove"; "coherence"];
   Goptions.optread = (fun () -> !opt_search_coh);
   Goptions.optwrite = (fun b -> opt_search_coh := b);
 }
@@ -23,8 +23,8 @@ let is_search_coh () = !opt_search_coh
 let opt_search_equiv = ref (false)
 let _ = Goptions.declare_bool_option {
   Goptions.optdepr = false;
-  Goptions.optname = "Generate proof of equivalence in search for DEVOID";
-  Goptions.optkey = ["DEVOID"; "search"; "prove"; "equivalence"];
+  Goptions.optname = "Generate proof of equivalence in search for CARROT";
+  Goptions.optkey = ["CARROT"; "search"; "prove"; "equivalence"];
   Goptions.optread = (fun () -> !opt_search_equiv);
   Goptions.optwrite = (fun b -> opt_search_equiv := b);
 }
@@ -38,8 +38,8 @@ let is_search_equiv () = !opt_search_equiv
 let opt_smart_elim = ref (false)
 let _ = Goptions.declare_bool_option {
   Goptions.optdepr = false;
-  Goptions.optname = "Generate useful eliminators for DEVOID";
-  Goptions.optkey = ["DEVOID"; "search"; "smart"; "eliminators"];
+  Goptions.optname = "Generate useful eliminators for CARROT";
+  Goptions.optkey = ["CARROT"; "search"; "smart"; "eliminators"];
   Goptions.optread = (fun () -> !opt_smart_elim);
   Goptions.optwrite = (fun b -> opt_smart_elim := b);
 }
@@ -53,8 +53,8 @@ let is_smart_elim () = !opt_smart_elim
 let opt_lift_type = ref (false)
 let _ = Goptions.declare_bool_option {
   Goptions.optdepr = false;
-  Goptions.optname = "Use lifted rather than inferred types in DEVOID";
-  Goptions.optkey = ["DEVOID"; "lift"; "type"];
+  Goptions.optname = "Use lifted rather than inferred types in CARROT";
+  Goptions.optkey = ["CARROT"; "lift"; "type"];
   Goptions.optread = (fun () -> !opt_lift_type);
   Goptions.optwrite = (fun b -> opt_lift_type := b);
 }
@@ -70,7 +70,7 @@ let opt_smart_cache = ref (true)
 let _ = Goptions.declare_bool_option {
   Goptions.optdepr = false;
   Goptions.optname = "Automatically cache unchanged lifted constants";
-  Goptions.optkey = ["DEVOID"; "smart"; "cache"];
+  Goptions.optkey = ["CARROT"; "smart"; "cache"];
   Goptions.optread = (fun () -> !opt_smart_cache);
   Goptions.optwrite = (fun b -> opt_smart_cache := b);
 }

--- a/plugin/src/options.mli
+++ b/plugin/src/options.mli
@@ -1,4 +1,4 @@
-(* --- Options for DEVOID --- *)
+(* --- Options for CARROT --- *)
 
        
 (*

--- a/plugin/src/ornaments/lifting.ml
+++ b/plugin/src/ornaments/lifting.ml
@@ -228,7 +228,7 @@ let initialize_lifting_cached env sigma o n =
       try
         Option.get (lookup_ornament (o, n))
       with _ ->
-        failwith "Cannot find cached ornament! Please report a bug in DEVOID"
+        failwith "Cannot find cached ornament! Please report a bug in CARROT"
     in
     let sigma, is_fwd = direction_cached env o promote k sigma in
     sigma, (is_fwd, (promote, forget), k)

--- a/plugin/test.sh
+++ b/plugin/test.sh
@@ -170,7 +170,7 @@ else
 fi
 cd ..
 
-echo "Running ITP paper examples."
+echo "Running paper examples."
 
 if coqc coq/examples/Intro.v
 then
@@ -323,49 +323,49 @@ else
   fi
   if [ $assumptions = false ]
   then
-    echo "Assumptions.v from ITP examples"
+    echo "Assumptions.v from examples"
   else
     :
   fi
   if [ $intro = false ]
   then
-    echo "Intro.v from ITP examples"
+    echo "Intro.v from examples"
   else
     :
   fi
   if [ $example = false ]
   then
-    echo "Example.v from ITP examples"
+    echo "Example.v from examples"
   else
     :
   fi
   if [ $liftspec = false ]
   then
-    echo "LiftSpec.v from ITP examples"
+    echo "LiftSpec.v from examples"
   else
     :
   fi
   if [ $search = false ]
   then
-    echo "Search.v from ITP examples"
+    echo "Search.v from examples"
   else
     :
   fi
   if [ $lift = false ]
   then
-    echo "Lift.v from ITP examples"
+    echo "Lift.v from examples"
   else
     :
   fi
   if [ $listtovect = false ]
   then
-    echo "ListToVect.v from ITP examples"
+    echo "ListToVect.v from examples"
   else
     :
   fi
   if [ $listtovectcustom = false ]
   then
-    echo "ListToVectCustom.v from extended ITP examples"
+    echo "ListToVectCustom.v from extended examples"
   else
     :
   fi


### PR DESCRIPTION
Largely the work of `grep`. Will add more to this PR as I go on

I am not tackling renaming DEVOID itself (outside of comments/the readme) because that would require modifications to Coq code

(For fun/checking, I grepped for the following using `-r *` from the project root: `talia`, `ringer`, `uwplse`, `plse`, `washington`, `cse`, `PUMPKIN`, `DEVOID`, `ITP`)